### PR TITLE
Patch debt equivalence error

### DIFF
--- a/dags/utils/vaults/debt_calculation.py
+++ b/dags/utils/vaults/debt_calculation.py
@@ -60,8 +60,7 @@ def _debt_calculation(**setup):
     ).fetchone()[0]
 
     # Output current debts on-chain vs in-db.
-    print(f"""in-db debt : {round(db_debt, 7)}""")
-    print(f"""on-chain debt : {round(d, 7)}""")
+    print(f"""in-db debt : {round(db_debt, 7)}\non-chain debt : {round(d, 7)}""")
     
     # Raise airflow exception if difference between debts exceeds |0.1|.
     # Otherwise, they are assumed to be quasi-equivalent, therefor correct.

--- a/dags/utils/vaults/debt_calculation.py
+++ b/dags/utils/vaults/debt_calculation.py
@@ -59,13 +59,14 @@ def _debt_calculation(**setup):
     """
     ).fetchone()[0]
 
-    from_chain = round(d, 2)
-    from_db = round(db_debt, 2)
-    print(f"""chain : {from_chain}""")
-    print(f"""db : {from_db}""")
-    test = from_chain == from_db
-    if not test:
-
+    # Output current debts on-chain vs in-db.
+    print(f"""in-db debt : {round(db_debt, 7)}""")
+    print(f"""on-chain debt : {round(d, 7)}""")
+    
+    # Raise airflow exception if difference between debts exceeds |0.1|.
+    # Otherwise, they are assumed to be quasi-equivalent, therefor correct.
+    calc = db_debt - d
+    if not (-.1 < calc < 0.1):
         raise AirflowFailException(f'WARNING: DEBT IS NOT CORRECT')
     
     try:


### PR DESCRIPTION
Only raise error if the difference between in-db and on-chain debt exceeds |0.1|.